### PR TITLE
Add test to prove TrimStrings and ConvertEmptyStringsToNull leak memory

### DIFF
--- a/app/Providers/MemoryLeakServiceProvider.php
+++ b/app/Providers/MemoryLeakServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Http\Middleware\TrimStrings;
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Support\ServiceProvider;
+
+class MemoryLeakServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        parent::register();
+
+        TrimStrings::skipWhen(fn (): bool => (bool) sleep(1));
+        ConvertEmptyStringsToNull::skipWhen(fn (): bool => false);
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -168,6 +168,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\MemoryLeakServiceProvider::class,
     ])->toArray(),
 
     /*

--- a/tests/Feature/MemoryLeakTest.php
+++ b/tests/Feature/MemoryLeakTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\TrimStrings;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Tests\TestCase;
+
+class MemoryLeakTest extends TestCase
+{
+    private const int NUMBER_OF_ITERATIONS = 100000;
+
+    public function testItDoesntRunOutOfMemory(): void
+    {
+        for ($i = 0; $i < self::NUMBER_OF_ITERATIONS; $i++) {
+            $kernel = $this->app->make(HttpKernel::class);
+
+            TrimStrings::skipWhen(fn (): bool => false);
+            ConvertEmptyStringsToNull::skipWhen(fn (): bool => false);
+
+            $kernel->terminate(new Request(), new Response());
+        }
+    }
+}

--- a/tests/Feature/MemoryLeakTest.php
+++ b/tests/Feature/MemoryLeakTest.php
@@ -4,26 +4,27 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
-use App\Http\Middleware\TrimStrings;
-use Illuminate\Contracts\Http\Kernel as HttpKernel;
-use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Tests\TestCase;
 
 class MemoryLeakTest extends TestCase
 {
-    private const int NUMBER_OF_ITERATIONS = 100000;
+    private const int NUMBER_OF_ITERATIONS = 10000;
 
-    public function testItDoesntRunOutOfMemory(): void
+    /**
+     * @dataProvider providesMemoryLeakTestIterations
+     */
+    public function testItDoesntRunOutOfMemory(int $iterationCount): void
     {
-        for ($i = 0; $i < self::NUMBER_OF_ITERATIONS; $i++) {
-            $kernel = $this->app->make(HttpKernel::class);
+        $response = $this->get('/');
 
-            TrimStrings::skipWhen(fn (): bool => false);
-            ConvertEmptyStringsToNull::skipWhen(fn (): bool => false);
+        $response->assertOk();
+    }
 
-            $kernel->terminate(new Request(), new Response());
-        }
+    public static function providesMemoryLeakTestIterations(): array
+    {
+        return array_map(
+            fn (int $iterationNumber): array => [$iterationNumber],
+            range(0, self::NUMBER_OF_ITERATIONS),
+        );
     }
 }


### PR DESCRIPTION
Running `php -d memory_limit={low memory limit like 25M} vendor/bin/phpunit tests/Feature/MemoryLeakTest.php` will result in the test running out of memory without a fix.